### PR TITLE
fixed path for css file in server file

### DIFF
--- a/src/server.imba
+++ b/src/server.imba
@@ -8,7 +8,7 @@ server.get '/' do |req,res|
 		<head>
 			<title> "Imba - Hello World"
 			<meta charset="utf-8">
-			<link rel="stylesheet" href="/dist/index.css" media="screen">
+			<link rel="stylesheet" href="/index.css" media="screen">
 		<body>
 			<script src="/client.js">
 	


### PR DESCRIPTION
The path was incorrectly set in the server.imba file.

Steps to reproduce:
- rename index.html to __index.html inside of /dist directory
- npm run build && npm run start